### PR TITLE
added device info for 2023 Legion Pro 5 16IRX8

### DIFF
--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -11,7 +11,8 @@ use std::{
 
 pub mod error;
 
-const KNOWN_DEVICE_INFOS: [(u16, u16, u16, u16); 6] = [
+const KNOWN_DEVICE_INFOS: [(u16, u16, u16, u16); 7] = [
+    (0x048d, 0xc985, 0xff89, 0x00cc), // 2023 Legion Pro 5 16IRX8
     (0x048d, 0xc984, 0xff89, 0x00cc), // 2023
     (0x048d, 0xc975, 0xff89, 0x00cc), // 2022
     (0x048d, 0xc973, 0xff89, 0x00cc), // 2022 Ideapad


### PR DESCRIPTION
I just got a Legion Pro 16IRX8 and the USB device information has changed:
```
$ lsusb | grep 048d
Bus 001 Device 003: ID 048d:c103 Integrated Technology Express, Inc. ITE Device(8910)
Bus 001 Device 002: ID 048d:c985 Integrated Technology Express, Inc. ITE Device(8295)
```

I've added this to the driver device info, compiled successfully, and verified that it is working (at least, it is on my laptop).