### PR TITLE
v0.19.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5110f1c78cf582855d895ecd0746b653db010cec6d9f5575293f27934d980a39"
 dependencies = [
  "ab_glyph_rasterizer",
- "owned_ttf_parser",
+ "owned_ttf_parser 0.19.0",
 ]
 
 [[package]]
@@ -103,12 +103,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
  "once_cell",
  "version_check",
 ]
@@ -253,6 +259,15 @@ name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits 0.2.15",
+]
 
 [[package]]
 name = "arboard"
@@ -445,6 +460,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "bindgen"
 version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,7 +644,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits 0.2.15",
- "time",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -824,6 +845,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "conv"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+dependencies = [
+ "custom_derive",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +981,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "custom_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
+
+[[package]]
 name = "dbus"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +1016,22 @@ checksum = "f456e698ae8e54575e19ddb1f9b7bce2298568524f215496b248eb9498b4f508"
 dependencies = [
  "dbus",
 ]
+
+[[package]]
+name = "deflate"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
+dependencies = [
+ "adler32",
+ "byteorder",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
 
 [[package]]
 name = "derivative"
@@ -1150,7 +1202,7 @@ dependencies = [
  "glow",
  "glutin",
  "glutin-winit",
- "image",
+ "image 0.24.6",
  "js-sys",
  "log",
  "objc",
@@ -1417,6 +1469,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-crate"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
+dependencies = [
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "find-winsdk"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,6 +1685,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
@@ -1633,6 +1705,16 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "gif"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3edd93c6756b4dfaf2709eafcc345ba2636565295c198a9cfbf75fa5e3e00b06"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -2099,6 +2181,25 @@ dependencies = [
 
 [[package]]
 name = "image"
+version = "0.23.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "gif 0.11.4",
+ "jpeg-decoder 0.1.22",
+ "num-iter",
+ "num-rational 0.3.2",
+ "num-traits 0.2.15",
+ "png 0.16.8",
+ "scoped_threadpool",
+ "tiff 0.6.1",
+]
+
+[[package]]
+name = "image"
 version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527909aa81e20ac3a44803521443a765550f09b5130c2c2fa1ea59c2f8f50a3a"
@@ -2107,13 +2208,29 @@ dependencies = [
  "byteorder",
  "color_quant",
  "exr",
- "gif",
- "jpeg-decoder",
+ "gif 0.12.0",
+ "jpeg-decoder 0.3.0",
  "num-rational 0.4.1",
  "num-traits 0.2.15",
- "png",
+ "png 0.17.9",
  "qoi",
- "tiff",
+ "tiff 0.8.1",
+]
+
+[[package]]
+name = "imageproc"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7923654f3ce7cb6849d5dc9e544aaeab49c508a90b56c721b046e7234c74ab53"
+dependencies = [
+ "conv",
+ "image 0.23.14",
+ "itertools",
+ "num 0.3.1",
+ "rand 0.7.3",
+ "rand_distr",
+ "rulinalg",
+ "rusttype",
 ]
 
 [[package]]
@@ -2240,6 +2357,12 @@ dependencies = [
 
 [[package]]
 name = "jpeg-decoder"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2"
+
+[[package]]
+name = "jpeg-decoder"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
@@ -2296,11 +2419,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 name = "legion-kb-rgb"
 version = "0.19.2"
 dependencies = [
- "bytes",
  "clap 4.3.5",
  "color-eyre",
  "crossbeam-channel",
- "crossbeam-utils",
  "device_query",
  "eframe",
  "egui-modal",
@@ -2308,11 +2429,11 @@ dependencies = [
  "egui_file",
  "error-stack",
  "fast_image_resize",
- "image",
+ "image 0.24.6",
  "legion-rgb-driver",
  "open",
+ "photon-rs",
  "rand 0.8.5",
- "regex",
  "scrap",
  "serde 1.0.164",
  "serde_json 1.0.97",
@@ -2441,6 +2562,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcad67dcec2d58ff56f6292582377e6921afdf3bfbd533e26fb8900ae575e002"
+dependencies = [
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2478,6 +2608,25 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+dependencies = [
+ "adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg 1.1.0",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -2522,7 +2671,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -2628,6 +2777,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
+dependencies = [
+ "num-integer",
+ "num-iter",
+ "num-traits 0.2.15",
+]
+
+[[package]]
+name = "num"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.3.2",
+ "num-traits 0.2.15",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-integer",
+ "num-traits 0.2.15",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
+dependencies = [
+ "num-traits 0.2.15",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,12 +2832,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-integer",
+ "num-traits 0.2.15",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg 1.1.0",
+ "num-bigint",
  "num-integer",
  "num-traits 0.2.15",
 ]
@@ -2821,11 +3027,20 @@ dependencies = [
 
 [[package]]
 name = "owned_ttf_parser"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e6affeb1632d6ff6a23d2cd40ffed138e82f1532571a26f527c8a284bb2fbb"
+dependencies = [
+ "ttf-parser 0.15.2",
+]
+
+[[package]]
+name = "owned_ttf_parser"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "706de7e2214113d63a8238d1910463cfce781129a6f263d13fdb09ff64355ba4"
 dependencies = [
- "ttf-parser",
+ "ttf-parser 0.19.1",
 ]
 
 [[package]]
@@ -2839,6 +3054,30 @@ name = "padlock"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c10569378a1dacd9f30dbe7ae49e054d2c45dc2f8ee49899903e09c3924e8b6f"
+
+[[package]]
+name = "palette"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9cd68f7112581033f157e56c77ac4a5538ec5836a2e39284e65bd7d7275e49"
+dependencies = [
+ "approx",
+ "num-traits 0.2.15",
+ "palette_derive",
+ "phf 0.11.2",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05eedf46a8e7c27f74af0c9cfcdb004ceca158cb1b918c6f68f8d7a549b3e427"
+dependencies = [
+ "find-crate",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "parking"
@@ -2894,12 +3133,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
+name = "perlin2d"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6c71cfd92099c43062f059494786cdcbd9cb4dab61389098362b241071cde0"
+
+[[package]]
 name = "phf"
 version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.7.24",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.11.2",
 ]
 
 [[package]]
@@ -2908,8 +3163,8 @@ version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.7.24",
+ "phf_shared 0.7.24",
 ]
 
 [[package]]
@@ -2918,8 +3173,31 @@ version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.7.24",
  "rand 0.6.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared 0.11.2",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2928,7 +3206,33 @@ version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 dependencies = [
- "siphasher",
+ "siphasher 0.2.3",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher 0.3.11",
+]
+
+[[package]]
+name = "photon-rs"
+version = "0.3.2"
+source = "git+https://github.com/4JX/photon?rev=53d9464#53d946448ef5d956763f39b632aa485f55916330"
+dependencies = [
+ "base64",
+ "image 0.23.14",
+ "imageproc",
+ "palette",
+ "perlin2d",
+ "rand 0.7.3",
+ "rusttype",
+ "serde 1.0.164",
+ "thiserror",
+ "time 0.3.26",
 ]
 
 [[package]]
@@ -2968,6 +3272,18 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "png"
+version = "0.16.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "deflate",
+ "miniz_oxide 0.3.7",
+]
 
 [[package]]
 name = "png"
@@ -3170,13 +3486,26 @@ dependencies = [
  "libc",
  "rand_chacha 0.1.1",
  "rand_core 0.4.2",
- "rand_hc",
+ "rand_hc 0.1.0",
  "rand_isaac",
  "rand_jitter",
  "rand_os",
  "rand_pcg",
  "rand_xorshift",
  "winapi",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
 ]
 
 [[package]]
@@ -3198,6 +3527,16 @@ checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
  "autocfg 0.1.8",
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3227,11 +3566,29 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96977acbdd3a6576fb1d27391900035bf3863d4a16422973a409b488cf29ffb2"
+dependencies = [
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -3241,6 +3598,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3301,6 +3667,12 @@ name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+
+[[package]]
+name = "rawpointer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebac11a9d2e11f2af219b8b8d833b76b1ea0e054aa0e8d8e9e4cbde353bdf019"
 
 [[package]]
 name = "rayon"
@@ -3369,7 +3741,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
  "redox_syscall 0.2.16",
  "thiserror",
 ]
@@ -3390,6 +3762,16 @@ name = "regex-syntax"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+
+[[package]]
+name = "rulinalg"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04ada202c9685e1d72a7420c578e92b358dbf807d3dfabb676a3dab9cc3bb12f"
+dependencies = [
+ "matrixmultiply",
+ "num 0.1.42",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -3427,6 +3809,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusttype"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff8374aa04134254b7995b63ad3dc41c7f7236f69528b28553da7d72efaa967"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser 0.15.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3452,6 +3844,12 @@ name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "scoped_threadpool"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 
 [[package]]
 name = "scopeguard"
@@ -3637,6 +4035,12 @@ name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -3869,7 +4273,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "013d134ae4a25ee744ad6129db589018558f620ddfa44043887cdd45fa08e75c"
 dependencies = [
- "phf",
+ "phf 0.7.24",
  "phf_codegen",
  "serde_json 0.9.10",
 ]
@@ -3938,12 +4342,23 @@ dependencies = [
 
 [[package]]
 name = "tiff"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a53f4706d65497df0c4349241deddf35f84cee19c87ed86ea8ca590f4464437"
+dependencies = [
+ "jpeg-decoder 0.1.22",
+ "miniz_oxide 0.4.4",
+ "weezl",
+]
+
+[[package]]
+name = "tiff"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7449334f9ff2baf290d55d73983a7d6fa15e01198faef72af07e2a8db851e471"
 dependencies = [
  "flate2",
- "jpeg-decoder",
+ "jpeg-decoder 0.3.0",
  "weezl",
 ]
 
@@ -3959,6 +4374,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a79d09ac6b08c1ab3906a2f7cc2e81a0e27c7ae89c63812df75e52bef0751e07"
+dependencies = [
+ "deranged",
+ "serde 1.0.164",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
 name = "tiny-skia"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3968,7 +4400,7 @@ dependencies = [
  "arrayvec",
  "bytemuck",
  "cfg-if",
- "png",
+ "png 0.17.9",
  "tiny-skia-path",
 ]
 
@@ -4178,6 +4610,12 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3e06c9b9d80ed6b745c7159c40b311ad2916abb34a49e9be2653b90db0d8dd"
+
+[[package]]
+name = "ttf-parser"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a464a4b34948a5f67fddd2b823c62d9d92e44be75058b99939eae6c5b6960b33"
@@ -4293,6 +4731,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,6 +804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "concat-string"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7439becb5fafc780b6f4de382b1a7a3e70234afe783854a4702ee8adbb838609"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1417,17 @@ dependencies = [
  "libc",
  "redox_syscall 0.2.16",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "find-winsdk"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8cbf17b871570c1f8612b763bac3e86290602bcf5dc3c5ce657e0e1e9071d9e"
+dependencies = [
+ "serde 1.0.164",
+ "serde_derive",
+ "winreg 0.5.1",
 ]
 
 [[package]]
@@ -2280,7 +2297,7 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "legion-kb-rgb"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "bytes",
  "clap 4.3.5",
@@ -2308,7 +2325,7 @@ dependencies = [
  "sysinfo",
  "thiserror",
  "tray-item",
- "winres",
+ "windres",
 ]
 
 [[package]]
@@ -2404,7 +2421,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26141aceb9f046065617266f41a4a652e4583da643472a10a89b4b3664d99eb6"
 dependencies = [
- "winreg",
+ "winreg 0.11.0",
 ]
 
 [[package]]
@@ -4147,8 +4164,9 @@ dependencies = [
 
 [[package]]
 name = "tray-item"
-version = "0.5.0-alpha"
-source = "git+https://github.com/njust/tray-item-rs#68c6afd4dc05ecbb051f2149b54934be9c9db8a5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e87dd77acd3451f2a894d1596cdd73f931972eef8847696a3c8376fce3f760"
 dependencies = [
  "cocoa",
  "core-graphics",
@@ -4158,7 +4176,7 @@ dependencies = [
  "objc-foundation",
  "objc_id",
  "padlock",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4212,9 +4230,9 @@ checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"
@@ -4734,6 +4752,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
+name = "windres"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82115619221b2b66001a39088b8059d171b1f9005a00d6a10c6e8a71a30a4cdc"
+dependencies = [
+ "concat-string",
+ "find-winsdk",
+]
+
+[[package]]
 name = "winit"
 version = "0.28.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4779,21 +4807,22 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a27a759395c1195c4cc5cda607ef6f8f6498f64e78f7900f5de0a127a424704a"
+dependencies = [
+ "serde 1.0.164",
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a1a57ff50e9b408431e8f97d5456f2807f8eb2a2cd79b06068fc87f8ecf189"
 dependencies = [
  "cfg-if",
  "winapi",
-]
-
-[[package]]
-name = "winres"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
-dependencies = [
- "toml 0.5.11",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "arboard"
@@ -375,12 +375,6 @@ dependencies = [
  "quote 1.0.28",
  "syn 2.0.18",
 ]
-
-[[package]]
-name = "atomic_refcell"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d6dc922a2792b006573f60b2648076355daeae5ce9cb59507e5908c9625d31"
 
 [[package]]
 name = "atspi"
@@ -1126,9 +1120,9 @@ checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "ecolor"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e479a7fa3f23d4e794f8b2f8b3568dd4e47886ad1b12c9c095e141cb591eb63"
+checksum = "cfdf4e52dbbb615cfd30cf5a5265335c217b5fd8d669593cea74a517d9c605af"
 dependencies = [
  "bytemuck",
 ]
@@ -1144,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4596583a2c680c55b6feaa748f74890c4f9cb9c7cb69d6117110444cb65b2f"
+checksum = "26d9efede6c8905d3fc51a5ec9a506d4da4011bbcae0253d0304580fe40af3f5"
 dependencies = [
  "bytemuck",
  "cocoa",
@@ -1160,8 +1154,10 @@ dependencies = [
  "js-sys",
  "log",
  "objc",
+ "parking_lot",
  "percent-encoding",
  "raw-window-handle",
+ "static_assertions",
  "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1172,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aef8ec3ae1b772f340170c65bf27d5b8c28f543a0116c844d2ac08d01123e7"
+checksum = "8bd69fed5fcf4fbb8225b24e80ea6193b61e17a625db105ef0c4d71dde6eb8b7"
 dependencies = [
  "accesskit",
  "ahash 0.8.3",
@@ -1185,51 +1181,53 @@ dependencies = [
 
 [[package]]
 name = "egui-modal"
-version = "0.2.4"
-source = "git+https://github.com/n00kii/egui-modal?rev=8443238#8443238deea231c175853b7308712b6133d309f3"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "930210dbd95b65bdd9251e0ab2e9db7572d58675f018c611d7e500b7ff5226b2"
 dependencies = [
  "egui",
 ]
 
 [[package]]
 name = "egui-notify"
-version = "0.6.0"
-source = "git+https://github.com/ItsEthra/egui-notify?rev=bc5eb67#bc5eb67db58ee663304560dd39ad6b06161ab24f"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3b10f21c7bb2afaecb8d98677cdb233a8b1f336b9b95abd610a33aeced04fc"
 dependencies = [
  "egui",
 ]
 
 [[package]]
 name = "egui-winit"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a49155fd4a0a4fb21224407a91de0030847972ef90fc64edb63621caea61cb2"
+checksum = "c15479a96d9fadccf5dac690bdc6373b97b8e1c0dd28367058f25a5298da0195"
 dependencies = [
  "accesskit_winit",
  "arboard",
  "egui",
- "instant",
  "log",
  "raw-window-handle",
  "smithay-clipboard",
+ "web-time",
  "webbrowser",
  "winit",
 ]
 
 [[package]]
 name = "egui_file"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ae1148e24a241824189ed51bc04487a36fa332c88039209225bcbfed2350d6"
+checksum = "7d36bb265b94d54e34378528b5895fbf132db63a8547376947f452edfda98d2d"
 dependencies = [
  "egui",
 ]
 
 [[package]]
 name = "egui_glow"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8c2752cdf1b0ef5fcda59a898cacabad974d4f5880e92a420b2c917022da64"
+checksum = "ce6726c08798822280038bbad2e32f4fc3cbed800cd51c6e34e99cd2d60cc1bc"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1248,9 +1246,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "emath"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3857d743a6e0741cdd60b622a74c7a36ea75f5f8f11b793b41d905d2c9721a4b"
+checksum = "1ef2b29de53074e575c18b694167ccbe6e5191f7b25fe65175a0d905a32eeec0"
 dependencies = [
  "bytemuck",
 ]
@@ -1291,13 +1289,12 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09333964d4d57f40a85338ba3ca5ed4716070ab184dcfed966b35491c5c64f3b"
+checksum = "58067b840d009143934d91d8dcb8ded054d8301d7c11a517ace0a99bb1e1595e"
 dependencies = [
  "ab_glyph",
  "ahash 0.8.3",
- "atomic_refcell",
  "bytemuck",
  "ecolor",
  "emath",
@@ -1339,9 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "error-stack"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f00447f331c7f726db5b8532ebc9163519eed03c6d7c8b73c90b3ff5646ac85"
+checksum = "27a72baa257b5e0e2de241967bc5ee8f855d6072351042688621081d66b2a76b"
 dependencies = [
  "anyhow",
  "rustc_version",
@@ -2320,8 +2317,8 @@ dependencies = [
  "serde 1.0.164",
  "serde_json 1.0.97",
  "single-instance",
- "strum 0.24.1",
- "strum_macros 0.24.3",
+ "strum 0.25.0",
+ "strum_macros 0.25.2",
  "sysinfo",
  "thiserror",
  "tray-item",
@@ -2783,9 +2780,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "open"
-version = "4.2.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a083c0c7e5e4a8ec4176346cf61f67ac674e8bfb059d9226e1c54a96b377c12"
+checksum = "cfabf1927dce4d6fdf563d63328a0a506101ced3ec780ca2135747336c98cef8"
 dependencies = [
  "is-wsl",
  "libc",
@@ -3774,9 +3771,9 @@ checksum = "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum_macros"
@@ -3792,15 +3789,15 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2 1.0.60",
  "quote 1.0.28",
  "rustversion",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -4465,6 +4462,16 @@ name = "web-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8208e3fdbc243c8fd30805721869242a7f6de3e2e9f3b057652ab36e52ae1e87"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,9 +369,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 2.0.18",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -386,9 +386,9 @@ version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 2.0.18",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -414,7 +414,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb4870a32c0eaa17e35bca0e6b16020635157121fb7d45593d242c295bc768"
 dependencies = [
- "quote 1.0.28",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -479,12 +479,12 @@ dependencies = [
  "log",
  "peeking_take_while",
  "prettyplease",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.18",
+ "syn 2.0.38",
  "which",
 ]
 
@@ -555,9 +555,9 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 2.0.18",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -707,9 +707,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 2.0.18",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1039,8 +1039,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1321,9 +1321,9 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 2.0.18",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1628,9 +1628,9 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 2.0.18",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1774,8 +1774,8 @@ dependencies = [
  "itertools",
  "proc-macro-crate 0.1.5",
  "proc-macro-error",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -2443,6 +2443,7 @@ dependencies = [
  "sysinfo",
  "thiserror",
  "tray-item",
+ "winapi",
  "windres",
 ]
 
@@ -2909,8 +2910,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -3074,8 +3075,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05eedf46a8e7c27f74af0c9cfcdb004ceca158cb1b918c6f68f8d7a549b3e427"
 dependencies = [
  "find-crate",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -3195,9 +3196,9 @@ checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
 dependencies = [
  "phf_generator 0.11.2",
  "phf_shared 0.11.2",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 2.0.18",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3250,9 +3251,9 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 2.0.18",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3332,8 +3333,8 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
 dependencies = [
- "proc-macro2 1.0.60",
- "syn 2.0.18",
+ "proc-macro2 1.0.69",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3362,8 +3363,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
  "version_check",
 ]
@@ -3374,8 +3375,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "version_check",
 ]
 
@@ -3390,9 +3391,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -3469,11 +3470,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.69",
 ]
 
 [[package]]
@@ -3922,9 +3923,9 @@ version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 2.0.18",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3956,9 +3957,9 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 2.0.18",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -4186,8 +4187,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
  "heck 0.3.3",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -4198,10 +4199,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "rustversion",
- "syn 2.0.18",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -4221,19 +4222,19 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "unicode-ident",
 ]
 
@@ -4325,9 +4326,9 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 2.0.18",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -4455,9 +4456,9 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 2.0.18",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -4555,9 +4556,9 @@ version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8803eee176538f94ae9a14b55b2804eb7e1441f8210b1c31290b3bccdccff73b"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 2.0.18",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -4769,9 +4770,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 2.0.18",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -4793,7 +4794,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote 1.0.28",
+ "quote 1.0.33",
  "wasm-bindgen-macro-support",
 ]
 
@@ -4803,9 +4804,9 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
- "syn 2.0.18",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4873,8 +4874,8 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f4303d8fa22ab852f789e75a967f0a2cdc430a607751c0499bada3e451cbd53"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "xml-rs",
 ]
 
@@ -5054,8 +5055,8 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce87ca8e3417b02dc2a8a22769306658670ec92d78f1bd420d6310a67c245c6"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -5065,8 +5066,8 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "853f69a591ecd4f810d29f17e902d40e349fb05b0b11fff63b08b826bfe39c7f"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -5379,8 +5380,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4832059b438689017db7340580ebabba07f114eab91bf990c6e55052408b40d8"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "regex",
  "syn 1.0.109",
 ]
@@ -5456,8 +5457,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d9c1b57352c25b778257c661f3c4744b7cefb7fc09dd46909a153cce7773da2"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
  "zvariant_utils",
 ]
@@ -5468,7 +5469,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200"
 dependencies = [
- "proc-macro2 1.0.60",
- "quote 1.0.28",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,7 +2417,7 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "legion-kb-rgb"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "clap 4.3.5",
  "color-eyre",
@@ -3222,7 +3222,7 @@ dependencies = [
 [[package]]
 name = "photon-rs"
 version = "0.3.2"
-source = "git+https://github.com/4JX/photon?rev=53d9464#53d946448ef5d956763f39b632aa485f55916330"
+source = "git+https://github.com/silvia-odwyer/photon?rev=3e8a2a6#3e8a2a68241d69c3980df7d149b65c3357001d14"
 dependencies = [
  "base64",
  "image 0.23.14",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["app", "driver"]
+resolver = "2"

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ The best way to add a new effect is to directly edit the source code, as it allo
 # Regular legions
 SUBSYSTEM=="usb", ATTR{idVendor}=="048d", ATTR{idProduct}=="c985", MODE="0666"
 SUBSYSTEM=="usb", ATTR{idVendor}=="048d", ATTR{idProduct}=="c984", MODE="0666"
+
+# LOQ Models
+SUBSYSTEM=="usb", ATTR{idVendor}=="048d", ATTR{idProduct}=="c983", MODE="0666"
 ```
 
 - **2022 Models:**

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion-kb-rgb"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["4JX"]
 edition = "2021"
 homepage = "https://github.com/4JX/L5P-Keyboard-RGB"
@@ -34,7 +34,7 @@ fast_image_resize = "2.4.0"
 # default-features = false just removes the use_wasm feature that removes a lot of unecessary slack
 # since this app wont ever use the web
 # photon-rs = { version = "0.3.2", default-features = false }
-photon-rs = { git = "https://github.com/4JX/photon", rev = "53d9464", default-features = false }
+photon-rs = { git = "https://github.com/silvia-odwyer/photon", rev = "3e8a2a6", default-features = false }
 
 
 # Keyboard and mouse grabbing

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -10,13 +10,11 @@ license = "GPL-3.0"
 
 [dependencies]
 legion-rgb-driver = { path = "../driver" }
-
 scrap = { git = "https://github.com/rustdesk/rustdesk", rev = "6c15dd6", features = [
     "wayland",
 ] }
 rand = "0.8.5"
 fast_image_resize = "2.4.0"
-tray-item = { version = "0.5.0-alpha", git = "https://github.com/njust/tray-item-rs" }
 clap = { version = "4.1.2", features = ["color", "cargo", "derive"] }
 strum = "0.24.1"
 strum_macros = "0.24.3"
@@ -45,9 +43,14 @@ bytes = "1.4.0"
 regex = "1.6.0"
 crossbeam-utils = "0.8.12"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+tray-item = { version = "0.8.0" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tray-item = { version = "0.8.0", features = ["ksni"] }
 
 [build-dependencies]
-winres = "0.1.12"
+windres = "0.2.2"
 
 [package.metadata.vcpkg]
 git = "https://github.com/microsoft/vcpkg"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -9,13 +9,38 @@ license = "GPL-3.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# Main driver
 legion-rgb-driver = { path = "../driver" }
+
+# Cli
+clap = { version = "4.1.2", features = ["color", "cargo", "derive"] }
+
+# Ui
+eframe = "0.23.0"
+egui-modal = "0.2.5"
+# egui-modal = { git = "https://github.com/n00kii/egui-modal", rev = "8443238" }
+egui_file = "0.11.0"
+egui-notify = "0.10.0"
+# egui-notify = { git = "https://github.com/ItsEthra/egui-notify", rev = "bc5eb67" }
+
+# App window, taskbar and tray icon loading
+image = "0.24.5"
+
+# AmbientLight effect
 scrap = { git = "https://github.com/rustdesk/rustdesk", rev = "6c15dd6", features = [
     "wayland",
 ] }
-rand = "0.8.5"
 fast_image_resize = "2.4.0"
-clap = { version = "4.1.2", features = ["color", "cargo", "derive"] }
+# default-features = false just removes the use_wasm feature that removes a lot of unecessary slack
+# since this app wont ever use the web
+# photon-rs = { version = "0.3.2", default-features = false }
+photon-rs = { git = "https://github.com/4JX/photon", rev = "53d9464", default-features = false }
+
+
+# Keyboard and mouse grabbing
+device_query = "1.1.3"
+
+rand = "0.8.5"
 strum = "0.25.0"
 strum_macros = "0.25.2"
 serde = { version = "1.0.152", features = ["derive"] }
@@ -25,23 +50,13 @@ sysinfo = "0.29.0"
 crossbeam-channel = "0.5.8"
 thiserror = "1.0.38"
 single-instance = "0.3.3"
-image = "0.24.5"
 open = "5.0.0"
 error-stack = "0.4.1"
-eframe = "0.23.0"
-egui-modal = "0.2.5"
-# egui-modal = { git = "https://github.com/n00kii/egui-modal", rev = "8443238" }
-egui_file = "0.11.0"
-egui-notify = "0.10.0"
-# egui-notify = { git = "https://github.com/ItsEthra/egui-notify", rev = "bc5eb67" }
-device_query = "1.1.3"
 
-# Fix version to stop cargo from yelling about dependency resolution
-bytes = "1.4.0"
+# Fix versions to stop cargo from yelling about dependency resolution
 
-# Dependabot alertsa
-regex = "1.6.0"
-crossbeam-utils = "0.8.12"
+# Dependabot alerts
+
 
 [target.'cfg(target_os = "windows")'.dependencies]
 tray-item = { version = "0.8.0" }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -52,6 +52,7 @@ thiserror = "1.0.38"
 single-instance = "0.3.3"
 open = "5.0.0"
 error-stack = "0.4.1"
+winapi = { version = "0.3.9", features = ["consoleapi", "wincon"] }
 
 # Fix versions to stop cargo from yelling about dependency resolution
 

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -2,7 +2,7 @@
 name = "legion-kb-rgb"
 version = "0.19.2"
 authors = ["4JX"]
-edition = "2018"
+edition = "2021"
 homepage = "https://github.com/4JX/L5P-Keyboard-RGB"
 license = "GPL-3.0"
 

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -16,8 +16,8 @@ scrap = { git = "https://github.com/rustdesk/rustdesk", rev = "6c15dd6", feature
 rand = "0.8.5"
 fast_image_resize = "2.4.0"
 clap = { version = "4.1.2", features = ["color", "cargo", "derive"] }
-strum = "0.24.1"
-strum_macros = "0.24.3"
+strum = "0.25.0"
+strum_macros = "0.25.2"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 color-eyre = "0.6.2"
@@ -26,14 +26,14 @@ crossbeam-channel = "0.5.8"
 thiserror = "1.0.38"
 single-instance = "0.3.3"
 image = "0.24.5"
-open = "4.1.0"
-error-stack = "0.3.1"
-eframe = "0.22.0"
-# egui-modal = "0.1.8"
-egui-modal = { git = "https://github.com/n00kii/egui-modal", rev = "8443238" }
-egui_file = "0.9.0"
-# egui-notify = "0.6.0"
-egui-notify = { git = "https://github.com/ItsEthra/egui-notify", rev = "bc5eb67" }
+open = "5.0.0"
+error-stack = "0.4.1"
+eframe = "0.23.0"
+egui-modal = "0.2.5"
+# egui-modal = { git = "https://github.com/n00kii/egui-modal", rev = "8443238" }
+egui_file = "0.11.0"
+egui-notify = "0.10.0"
+# egui-notify = { git = "https://github.com/ItsEthra/egui-notify", rev = "bc5eb67" }
 device_query = "1.1.3"
 
 # Fix version to stop cargo from yelling about dependency resolution

--- a/app/build.rs
+++ b/app/build.rs
@@ -1,9 +1,9 @@
-extern crate winres;
+extern crate windres;
 
 fn main() {
-    if cfg!(target_os = "windows") {
-        let mut res = winres::WindowsResource::new();
-        res.set_icon_with_id("./res/trayIcon.ico", "trayIcon");
-        res.compile().unwrap();
+    #[cfg(target_os = "windows")]
+    {
+        use windres::Build;
+        Build::new().compile("./res/resources.rc").unwrap();
     }
 }

--- a/app/res/resources.rc
+++ b/app/res/resources.rc
@@ -1,0 +1,1 @@
+trayIcon ICON "trayIcon.ico"

--- a/app/src/cli.rs
+++ b/app/src/cli.rs
@@ -144,7 +144,7 @@ pub fn try_cli(is_unique_instance: bool) -> Result<CliOutput, CliError> {
     let Some(subcommand) = cli.command else {
         let exec_name = std::env::current_exe().unwrap().file_name().unwrap().to_string_lossy().into_owned();
         println!("No subcommands found, starting in GUI mode. To view the possible subcommands type \"{exec_name} --help\".",);
-        return  Ok(CliOutput::maybe_gui(true, cli.hide_window, OutputType::NoArgs))
+        return Ok(CliOutput::maybe_gui(true, cli.hide_window, OutputType::NoArgs));
     };
 
     // Early logic for specific subcommands

--- a/app/src/cli.rs
+++ b/app/src/cli.rs
@@ -185,7 +185,7 @@ pub fn try_cli(is_unique_instance: bool) -> Result<CliOutput, CliError> {
             };
 
             if let Some(filename) = save {
-                profile.save_profile(filename).expect("Failed to save.");
+                profile.save_profile(&filename).expect("Failed to save.");
             }
 
             Ok(CliOutput::maybe_gui(cli.gui, cli.hide_window, OutputType::Profile(profile)))
@@ -200,13 +200,13 @@ pub fn try_cli(is_unique_instance: bool) -> Result<CliOutput, CliError> {
         }
 
         Commands::LoadProfile { path } => {
-            let profile = Profile::load_profile(path).change_context(CliError)?;
+            let profile = Profile::load_profile(&path).change_context(CliError)?;
 
             Ok(CliOutput::maybe_gui(cli.gui, cli.hide_window, OutputType::Profile(profile)))
         }
 
         Commands::CustomEffect { path } => {
-            let effect = CustomEffect::from_file(path).change_context(CliError)?;
+            let effect = CustomEffect::from_file(&path).change_context(CliError)?;
 
             Ok(CliOutput::maybe_gui(cli.gui, cli.hide_window, OutputType::Custom(effect)))
         }

--- a/app/src/console.rs
+++ b/app/src/console.rs
@@ -1,0 +1,47 @@
+// Carefully stolen from
+// https://www.reddit.com/r/rust/comments/e7slkw/how_to_show_and_hide_a_terminal_window/
+// https://github.com/Freaky/Compactor/blob/1b4e7142e3cd732689c012eb796f12ebb5b166ef/src/console.rs
+
+// Helper functions for handling the Windows console from a GUI context.
+//
+// Windows subsystem applications must explicitly attach to an existing console
+// before stdio works, and if not available, create their own if they wish to
+// print anything.
+//
+// These functions enable that, primarily for the purposes of displaying Rust
+// panics.
+
+use winapi::um::consoleapi::AllocConsole;
+use winapi::um::wincon::{AttachConsole, FreeConsole, GetConsoleWindow, ATTACH_PARENT_PROCESS};
+
+/// Check if we're attached to an existing Windows console
+pub fn is_attached() -> bool {
+    unsafe { !GetConsoleWindow().is_null() }
+}
+
+/// Try to attach to an existing Windows console, if necessary.
+///
+/// It's normally a no-brainer to call this - it just makes println! and friends
+/// work as expected, without cluttering the screen with a console in the general
+/// case.
+pub fn attach() -> bool {
+    if is_attached() {
+        return true;
+    }
+
+    unsafe { AttachConsole(ATTACH_PARENT_PROCESS) != 0 }
+}
+
+/// Try to attach to a console, and if not, allocate ourselves a new one.
+pub fn alloc() -> bool {
+    if attach() {
+        return true;
+    }
+
+    unsafe { AllocConsole() != 0 }
+}
+
+/// Free any allocated console, if any.
+pub fn free() {
+    unsafe { FreeConsole() };
+}

--- a/app/src/effects/ambient.rs
+++ b/app/src/effects/ambient.rs
@@ -40,6 +40,7 @@ impl AmbientLight {
             while !manager.stop_signals.keyboard_stop_signal.load(Ordering::SeqCst) {
                 let now = Instant::now();
 
+                #[allow(clippy::single_match)]
                 match capturer.frame(seconds_per_frame) {
                     Ok(frame) => {
                         let rgb = process_frame(&frame, dimensions, &mut resizer);

--- a/app/src/effects/ambient.rs
+++ b/app/src/effects/ambient.rs
@@ -19,7 +19,7 @@ struct ScreenDimensions {
 pub(super) struct AmbientLight;
 
 impl AmbientLight {
-    pub fn play(manager: &mut super::Inner, fps: u8) {
+    pub fn play(manager: &mut super::Inner, fps: u8, saturation_boost: f32) {
         while !manager.stop_signals.manager_stop_signal.load(Ordering::SeqCst) {
             //Display setup
             let display = Display::all().unwrap().remove(0);
@@ -43,7 +43,7 @@ impl AmbientLight {
                 #[allow(clippy::single_match)]
                 match capturer.frame(seconds_per_frame) {
                     Ok(frame) => {
-                        let rgb = process_frame(&frame, dimensions, &mut resizer);
+                        let rgb = process_frame(&frame, dimensions, &mut resizer, saturation_boost);
 
                         manager.keyboard.set_colors_to(&rgb).unwrap();
                         #[cfg(target_os = "windows")]
@@ -83,7 +83,7 @@ impl AmbientLight {
     }
 }
 
-fn process_frame(frame: &Frame, dimensions: ScreenDimensions, resizer: &mut Resizer) -> [u8; 12] {
+fn process_frame(frame: &Frame, dimensions: ScreenDimensions, resizer: &mut Resizer, saturation_boost: f32) -> [u8; 12] {
     // Adapted from https://github.com/Cykooz/fast_image_resize#resize-image
     // Read source image from file
 
@@ -116,12 +116,25 @@ fn process_frame(frame: &Frame, dimensions: ScreenDimensions, resizer: &mut Resi
 
     let bgr_arr = dst_image.buffer();
 
-    // BGRA -> RGB
-    let mut rgb: [u8; 12] = [0; 12];
-    for (src, dst) in bgr_arr.chunks_exact(4).zip(rgb.chunks_exact_mut(3)) {
+    // BGRA -> RGBA
+    let mut rgba: [u8; 16] = [0; 16];
+    for (src, dst) in bgr_arr.chunks_exact(4).zip(rgba.chunks_exact_mut(4)) {
         dst[0] = src[2];
         dst[1] = src[1];
         dst[2] = src[0];
+        dst[3] = src[3];
+    }
+
+    let mut img = photon_rs::PhotonImage::new(rgba.to_vec(), 4, 1);
+    photon_rs::colour_spaces::saturate_hsv(&mut img, saturation_boost);
+
+    // RGBA -> RGB
+    let raw = img.get_raw_pixels();
+    let mut rgb: [u8; 12] = [0; 12];
+    for (src, dst) in raw.chunks_exact(4).zip(rgb.chunks_exact_mut(3)) {
+        dst[0] = src[0];
+        dst[1] = src[1];
+        dst[2] = src[2];
     }
 
     rgb

--- a/app/src/effects/custom_effect.rs
+++ b/app/src/effects/custom_effect.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use error_stack::{Result, ResultExt};
 use serde::{Deserialize, Serialize};
@@ -33,7 +33,7 @@ pub struct CustomEffect {
 pub struct LoadCustomEffectError;
 
 impl CustomEffect {
-    pub fn from_file(path: PathBuf) -> Result<Self, LoadCustomEffectError> {
+    pub fn from_file(path: &Path) -> Result<Self, LoadCustomEffectError> {
         Self::load(path).change_context(LoadCustomEffectError)
     }
 }

--- a/app/src/effects/mod.rs
+++ b/app/src/effects/mod.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 use crossbeam_channel::{Receiver, Sender};
-use error_stack::{IntoReport, Result, ResultExt};
+use error_stack::{Result, ResultExt};
 use legion_rgb_driver::{BaseEffects, Keyboard, SPEED_RANGE};
 use rand::thread_rng;
 use std::{
@@ -74,7 +74,6 @@ impl EffectManager {
         };
 
         let keyboard = legion_rgb_driver::get_keyboard(stop_signals.keyboard_stop_signal.clone())
-            .into_report()
             .change_context(AcquireKeyboardError)
             .attach_printable("Ensure that you have a supported model and that the application has access to it.")
             .attach_printable("On Linux, see https://github.com/4JX/L5P-Keyboard-RGB#usage")

--- a/app/src/effects/mod.rs
+++ b/app/src/effects/mod.rs
@@ -172,10 +172,11 @@ impl Inner {
             },
 
             Effects::Lightning => Lightning::play(self, &profile, &mut thread_rng),
-            Effects::AmbientLight { mut fps } => {
+            Effects::AmbientLight { mut fps, mut saturation_boost } => {
                 fps = fps.clamp(1, 60);
+                saturation_boost = saturation_boost.clamp(0.0, 1.0);
 
-                AmbientLight::play(self, fps);
+                AmbientLight::play(self, fps, saturation_boost);
             }
             Effects::SmoothWave => {
                 profile.rgb_zones = profile::arr_to_zones([255, 0, 0, 0, 255, 0, 0, 0, 255, 255, 0, 255]);

--- a/app/src/effects/ripple.rs
+++ b/app/src/effects/ripple.rs
@@ -154,11 +154,11 @@ impl Ripple {
             let guard = state.on_key_down(move |key| {
                 stop_signals.keyboard_stop_signal.store(true, Ordering::SeqCst);
 
-                let _ = tx_clone.send(Event::KeyPress(key.clone()));
+                let _ = tx_clone.send(Event::KeyPress(*key));
             });
 
             let guard2 = state.on_key_up(move |key| {
-                let _ = tx.send(Event::KeyRelease(key.clone()));
+                let _ = tx.send(Event::KeyRelease(*key));
             });
 
             loop {

--- a/app/src/effects/ripple.rs
+++ b/app/src/effects/ripple.rs
@@ -239,13 +239,16 @@ fn advance_zone_state(zone_state: [RippleMove; 4], last_step_time: &mut Instant,
         *last_step_time = now;
 
         // Process moves first, then add centers
-        for (i, ripple_move) in zone_state.iter().enumerate() {
-            match ripple_move {
+        for (i, zone_move) in zone_state.iter().enumerate() {
+            match zone_move {
                 RippleMove::Left => {
-                    if let Some(left) = new_state.get_mut(i - 1) {
-                        *left = RippleMove::Left;
+                    if i != 0 {
+                        if let Some(left) = new_state.get_mut(i - 1) {
+                            *left = RippleMove::Left;
+                        }
                     }
                 }
+
                 RippleMove::Right => {
                     if let Some(right) = new_state.get_mut(i + 1) {
                         *right = RippleMove::Right;
@@ -257,8 +260,10 @@ fn advance_zone_state(zone_state: [RippleMove; 4], last_step_time: &mut Instant,
 
         for (i, ripple_move) in zone_state.iter().enumerate() {
             if let RippleMove::Center = ripple_move {
-                if let Some(left) = new_state.get_mut(i - 1) {
-                    *left = RippleMove::Left;
+                if i != 0 {
+                    if let Some(left) = new_state.get_mut(i - 1) {
+                        *left = RippleMove::Left;
+                    }
                 }
 
                 if let Some(right) = new_state.get_mut(i + 1) {

--- a/app/src/enums.rs
+++ b/app/src/enums.rs
@@ -2,7 +2,7 @@ use crate::{effects::custom_effect::CustomEffect, profile::Profile};
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumIter, EnumString, IntoStaticStr};
 
-#[derive(Clone, Copy, EnumString, Serialize, Deserialize, Display, EnumIter, Eq, Debug, IntoStaticStr, Default)]
+#[derive(Clone, Copy, EnumString, Serialize, Deserialize, Display, EnumIter, Debug, IntoStaticStr, Default)]
 pub enum Effects {
     #[default]
     Static,
@@ -12,6 +12,7 @@ pub enum Effects {
     Lightning,
     AmbientLight {
         fps: u8,
+        saturation_boost: f32,
     },
     SmoothWave,
     Swipe,

--- a/app/src/gui/effect_options.rs
+++ b/app/src/gui/effect_options.rs
@@ -49,18 +49,22 @@ impl EffectOptions {
                     });
             });
 
-            if let Effects::AmbientLight { fps } = &mut profile.effect {
+            if let Effects::AmbientLight { fps, saturation_boost: saturation } = &mut profile.effect {
                 ui.horizontal(|ui| {
                     *update_lights |= ui.add(Slider::new(fps, 1..=60)).changed();
                     ui.label("FPS");
-                })
+                });
+                ui.horizontal(|ui| {
+                    *update_lights |= ui.add(Slider::new(saturation, 0.0..=1.0)).changed();
+                    ui.label("Saturation Boost");
+                });
             } else {
                 let range = if profile.effect.is_built_in() { SPEED_RANGE } else { 1..=10 };
 
                 ui.horizontal(|ui| {
                     *update_lights |= ui.add_enabled(profile.effect.takes_speed(), Slider::new(&mut profile.speed, range)).changed();
                     ui.label("Speed");
-                })
+                });
             }
         });
     }

--- a/app/src/gui/menu_bar.rs
+++ b/app/src/gui/menu_bar.rs
@@ -46,7 +46,7 @@ impl MenuBarState {
         if let Some(dialog) = &mut self.open_file_dialog {
             if dialog.show(ctx).selected() {
                 if let Some(path) = dialog.path() {
-                    self.opened_file = Some(path.clone());
+                    self.opened_file = Some(path.to_owned());
                     if let Some(kind) = &self.file_kind {
                         match kind {
                             FileOperation::LoadProfile => match Profile::load_profile(path) {

--- a/app/src/gui/menu_bar.rs
+++ b/app/src/gui/menu_bar.rs
@@ -121,6 +121,23 @@ impl MenuBarState {
             if ui.button("Exit").clicked() {
                 self.gui_sender.send(GuiMessage::Quit).unwrap();
             }
+
+            #[cfg(target_os = "windows")]
+            {
+                use crate::console;
+                use eframe::{egui::Layout, emath::Align};
+                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                    if ui.button("📜").clicked() {
+                        if !console::alloc() {
+                            self.toasts
+                                .error("Could not allocate debug terminal.")
+                                .set_duration(Some(Duration::from_millis(5000)))
+                                .set_closable(true);
+                        }
+                        println!("Debug terminal enabled.");
+                    }
+                });
+            }
         });
     }
 

--- a/app/src/gui/mod.rs
+++ b/app/src/gui/mod.rs
@@ -1,14 +1,11 @@
-use std::{
-    mem,
-    path::{Path, PathBuf},
-    process, thread,
-    time::Duration,
-};
+use std::{mem, path::Path, process, thread, time::Duration};
 
 use crossbeam_channel::{Receiver, Sender};
 use device_query::{DeviceQuery, Keycode};
+#[cfg(debug_assertions)]
+use eframe::egui::style::DebugOptions;
 use eframe::{
-    egui::{style::DebugOptions, CentralPanel, Context, Frame, Layout, ScrollArea, Style, TopBottomPanel},
+    egui::{CentralPanel, Context, Frame, Layout, ScrollArea, Style, TopBottomPanel},
     emath::Align,
     epaint::{Color32, Rounding, Vec2},
     CreationContext,
@@ -302,9 +299,9 @@ impl eframe::App for App {
     }
 
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
-        let path = PathBuf::from("./settings.json");
+        let path = Path::new("./settings.json");
 
-        let mut settings = Settings::load_or_default(&path);
+        let mut settings = Settings::load_or_default(path);
 
         settings.profiles = std::mem::take(&mut self.profile_list.profiles);
 
@@ -319,8 +316,11 @@ impl App {
         let style = Style {
             // text_styles: text_utils::default_text_styles(),
             visuals: self.theme.visuals.clone(),
+            #[cfg(debug_assertions)]
             debug: DebugOptions {
                 debug_on_hover: false,
+                debug_on_hover_with_all_modifiers: false,
+                hover_shows_next: false,
                 show_expand_width: false,
                 show_expand_height: false,
                 show_resize: false,

--- a/app/src/gui/mod.rs
+++ b/app/src/gui/mod.rs
@@ -120,10 +120,22 @@ impl App {
             let mut is_err = false;
 
             let show_sender = gui_sender.clone();
-            is_err |= tray.add_menu_item("Show", move || show_sender.send(GuiMessage::ShowWindow).unwrap()).is_err();
+            let egui_ctx = cc.egui_ctx.clone();
+            is_err |= tray
+                .add_menu_item("Show", move || {
+                    egui_ctx.request_repaint();
+                    show_sender.send(GuiMessage::ShowWindow).unwrap()
+                })
+                .is_err();
 
             let quit_sender = gui_sender.clone();
-            is_err |= tray.add_menu_item("Quit", move || quit_sender.send(GuiMessage::Quit).unwrap()).is_err();
+            let egui_ctx = cc.egui_ctx.clone();
+            is_err |= tray
+                .add_menu_item("Quit", move || {
+                    egui_ctx.request_repaint();
+                    quit_sender.send(GuiMessage::Quit).unwrap()
+                })
+                .is_err();
 
             if !is_err {
                 Some(tray)

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -6,7 +6,7 @@ mod persist;
 mod profile;
 mod util;
 
-use cli::CliOutput;
+use cli::{CliOutput, OutputType};
 use color_eyre::{eyre::eyre, Result};
 use effects::EffectManager;
 use eframe::{epaint::Vec2, IconData};
@@ -48,28 +48,49 @@ fn main() -> Result<()> {
 
     let cli_output = cli::try_cli(is_unique).map_err(|err| eyre!("{:?}", err))?;
 
-    if let Some(hide_window) = cli_output.start_gui_maybe_hidden {
-        start_ui(cli_output, is_unique, hide_window);
+    match cli_output {
+        CliOutput::Gui { hide_window, output } => {
+            start_ui(output, is_unique, hide_window);
 
-        Ok(())
-    } else {
-        let mut effect_manager = EffectManager::new(effects::OperationMode::Cli).unwrap();
+            Ok(())
+        }
+        CliOutput::Cli(output) => {
+            let mut effect_manager = EffectManager::new(effects::OperationMode::Cli).unwrap();
 
-        match cli_output.output {
-            cli::CliOutputType::Profile(profile) => {
-                effect_manager.set_profile(profile);
-                effect_manager.join_and_exit();
-                Ok(())
+            match output {
+                cli::OutputType::Profile(profile) => {
+                    effect_manager.set_profile(profile);
+                    effect_manager.join_and_exit();
+                    Ok(())
+                }
+                cli::OutputType::Custom(effect) => {
+                    effect_manager.custom_effect(effect);
+                    effect_manager.join_and_exit();
+                    Ok(())
+                }
+                cli::OutputType::Exit => Ok(()),
+                cli::OutputType::NoArgs => unreachable!("No arguments were provided but the app is in CLI mode"),
             }
-            cli::CliOutputType::Custom(effect) => {
-                effect_manager.custom_effect(effect);
-                effect_manager.join_and_exit();
-                Ok(())
-            }
-            cli::CliOutputType::Exit => Ok(()),
-            cli::CliOutputType::NoArgs => unreachable!("No arguments were provided but the app is in CLI mode"),
         }
     }
+}
+
+fn start_ui(output_type: OutputType, is_unique: bool, hide_window: bool) {
+    let app_icon = load_icon_data(include_bytes!("../res/trayIcon.ico"));
+    let native_options = eframe::NativeOptions {
+        initial_window_size: Some(WINDOW_SIZE),
+        min_window_size: Some(WINDOW_SIZE),
+        max_window_size: Some(WINDOW_SIZE),
+        icon_data: Some(app_icon),
+        ..eframe::NativeOptions::default()
+    };
+
+    let (gui_sender, gui_receiver) = crossbeam_channel::unbounded::<GuiMessage>();
+
+    let gui_sender_clone = gui_sender.clone();
+    let app = App::new(output_type, hide_window, is_unique, gui_sender_clone, gui_receiver);
+
+    eframe::run_native("Legion RGB", native_options, Box::new(|cc| Box::new(app.init(cc, gui_sender)))).unwrap();
 }
 
 #[must_use]
@@ -83,22 +104,4 @@ fn load_icon_data(image_data: &[u8]) -> IconData {
         width: image.width(),
         height: image.height(),
     }
-}
-
-fn start_ui(cli_output: CliOutput, is_unique: bool, hide_window: bool) {
-    let app_icon = load_icon_data(include_bytes!("../res/trayIcon.ico"));
-    let native_options = eframe::NativeOptions {
-        initial_window_size: Some(WINDOW_SIZE),
-        min_window_size: Some(WINDOW_SIZE),
-        max_window_size: Some(WINDOW_SIZE),
-        icon_data: Some(app_icon),
-        ..eframe::NativeOptions::default()
-    };
-
-    let (gui_sender, gui_receiver) = crossbeam_channel::unbounded::<GuiMessage>();
-
-    let gui_sender_clone = gui_sender.clone();
-    let app = App::new(cli_output.output, hide_window, is_unique, gui_sender_clone, gui_receiver);
-
-    eframe::run_native("Legion RGB", native_options, Box::new(|cc| Box::new(app.init(cc, gui_sender)))).unwrap();
 }

--- a/app/src/profile.rs
+++ b/app/src/profile.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryInto, path::PathBuf};
+use std::{convert::TryInto, path::Path};
 
 use crate::{
     enums::{Brightness, Direction, Effects},
@@ -58,11 +58,11 @@ pub struct LoadProfileError;
 pub struct SaveProfileError;
 
 impl Profile {
-    pub fn load_profile(path: PathBuf) -> Result<Self, LoadProfileError> {
+    pub fn load_profile(path: &Path) -> Result<Self, LoadProfileError> {
         Self::load(path).change_context(LoadProfileError)
     }
 
-    pub fn save_profile(&self, path: PathBuf) -> Result<(), SaveProfileError> {
+    pub fn save_profile(&self, path: &Path) -> Result<(), SaveProfileError> {
         self.save(path).change_context(SaveProfileError)
     }
 

--- a/app/src/util.rs
+++ b/app/src/util.rs
@@ -1,9 +1,9 @@
 use clap::crate_name;
 use eframe::egui::Ui;
-use error_stack::{IntoReport, Result, ResultExt};
+use error_stack::{Result, ResultExt};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use single_instance::SingleInstance;
-use std::{fs::File, io::Write, path::PathBuf};
+use std::{fs::File, io::Write, path::Path};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -19,20 +19,20 @@ where
     Self: DeserializeOwned + Serialize + Sized,
     for<'de> Self: Deserialize<'de> + 'a,
 {
-    fn load(path: PathBuf) -> Result<Self, LoadFileError> {
-        let file = std::fs::File::open(path).into_report().change_context(LoadFileError)?;
+    fn load(path: &Path) -> Result<Self, LoadFileError> {
+        let file = std::fs::File::open(path).change_context(LoadFileError)?;
 
         let reader = std::io::BufReader::new(file);
 
-        serde_json::de::from_reader(reader).into_report().change_context(LoadFileError)
+        serde_json::de::from_reader(reader).change_context(LoadFileError)
     }
 
-    fn save(&self, path: PathBuf) -> Result<(), SaveFileError> {
-        let mut file = File::create(path).into_report().change_context(SaveFileError)?;
+    fn save(&self, path: &Path) -> Result<(), SaveFileError> {
+        let mut file = File::create(path).change_context(SaveFileError)?;
 
-        let stringified_json = serde_json::to_string(&self).into_report().change_context(SaveFileError)?;
+        let stringified_json = serde_json::to_string(&self).change_context(SaveFileError)?;
 
-        file.write_all(stringified_json.as_bytes()).into_report().change_context(SaveFileError)?;
+        file.write_all(stringified_json.as_bytes()).change_context(SaveFileError)?;
 
         Ok(())
     }

--- a/app/src/util.rs
+++ b/app/src/util.rs
@@ -1,8 +1,6 @@
-use clap::crate_name;
 use eframe::egui::Ui;
 use error_stack::{Result, ResultExt};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use single_instance::SingleInstance;
 use std::{fs::File, io::Write, path::Path};
 use thiserror::Error;
 
@@ -36,10 +34,6 @@ where
 
         Ok(())
     }
-}
-
-pub fn is_unique_instance() -> bool {
-    SingleInstance::new(crate_name!()).unwrap().is_single()
 }
 
 pub fn clickable_link(ui: &mut Ui, url: &str) {

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1687211417,
-        "narHash": "sha256-VkPp8IJYlxp5Iph9n+2+zHHTSpfF3l9OxYqieD4OKeI=",
+        "lastModified": 1697165857,
+        "narHash": "sha256-Cho+TPHCIfx/sVo5scjNDP2XUCpUxcyKvoMlJ8w9dgQ=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "bd65e0e473f55cfd6b4e6d9f1afb360468f3638a",
+        "rev": "117ac48319c0dbcff5540781c7c5b18166e33f6a",
         "type": "github"
       },
       "original": {
@@ -26,11 +26,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696267196,
+        "narHash": "sha256-AAQ/2sD+0D18bb8hKuEEVpHUYD1GmO2Uh/taFamn6XQ=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "4f910c9827911b1ec2bf26b5a062cd09f8d89f85",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1687171271,
-        "narHash": "sha256-BJlq+ozK2B1sJDQXS3tzJM5a+oVZmi1q0FlBK/Xqv7M=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687130670,
-        "narHash": "sha256-VKTdfsJe7sVTTqxTd3eRGPoUgEeJKD+kwS86B6TY874=",
+        "lastModified": 1697009197,
+        "narHash": "sha256-viVRhBTFT8fPJTb1N3brQIpFZnttmwo3JVKNuWRVc3s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c1bca7fe84c646cfd4ebf3482c0e6317a0b13f22",
+        "rev": "01441e14af5e29c9d27ace398e6dd0b293e25a54",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685759304,
-        "narHash": "sha256-I3YBH6MS3G5kGzNuc1G0f9uYfTcNY9NYoRc3QsykLk4=",
+        "lastModified": 1696299134,
+        "narHash": "sha256-RS77cAa0N+Sfj5EmKbm5IdncNXaBCE1BSSQvUE8exvo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c535b4f3327910c96dcf21851bbdd074d0760290",
+        "rev": "611ccdceed92b4d94ae75328148d84ee4a5b462d",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687141659,
-        "narHash": "sha256-ckvEuxejYmFTyFF0u9CWV8h5u+ubuxA7vYrOw/GXRXg=",
+        "lastModified": 1697163235,
+        "narHash": "sha256-HzGr9LbTKf8x4NeDH94i1J2Cq/0CY1Qrt4z5pETk9HA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "86302751ef371597d48951983e1a2f04fe78d4ff",
+        "rev": "b48a7e5dab1b472dd9c9ee9053401489dbb4d6fc",
         "type": "github"
       },
       "original": {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,4 @@
 # https://rust-lang.github.io/rustfmt/?version=master&search=
-fn_args_layout = "Compressed"
-# hard_tabs = true
+fn_params_layout = "Compressed"
 max_width = 200
 use_try_shorthand = true


### PR DESCRIPTION
### New
- Added a saturation boost slider to `AmbientLight`
  - **Breaking:** Profiles (in `settings.json` or standalone) now have a `saturation_boost` field, please add a `saturation_boost` entry into any saved profiles that have the `AmbientLight` effect (ie.  `"effect": {"AmbientLight": {"fps": 0, "saturation_boost": 0.0}},`)
### Fixes
- On Windows the CLI was not properly hidden if using the Windows Terminal (New default for Windows 11) #89 
- Tray icon is unresponsive #122 
- Detection for already running instances did not always work #140 

 

**Full Changelog**: https://github.com/4JX/L5P-Keyboard-RGB/compare/v0.19.2...v0.19.3