### PR TITLE
Support building without `vcpkg`

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,15 @@ cd L5P-Keyboard-RGB/
 cargo build --release
 ```
 
+### Building manually (Without vcpkg)
+
+If you don't need the **AmbientLight** effect (keyboard mirroring) or don't have the required video libraries, you can build without it:
+
+```sh
+cd L5P-Keyboard-RGB/
+cargo build --release --no-default-features
+```
+
 ## Crashes, freezes, etc
 
 I cannot guarantee this solution will work for anyone but myself. That being said feel free to open an issue if you encounter any of these problems on the [issues tab](https://github.com/4JX/L5P-Keyboard-RGB/issues).

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -31,8 +31,7 @@ image = "0.25.6"
 # AmbientLight effect
 scrap = { git = "https://github.com/rustdesk/rustdesk", rev = "4d3ccc6", features = [
     "wayland",
-    # "linux-pkg-config",
-] }
+], optional = true }
 fast_image_resize = "5.1.3"
 # default-features = false just removes the use_wasm feature that removes a lot of unecessary slack
 # since this app wont ever use the web
@@ -74,10 +73,12 @@ winres = "0.1.12"
 
 # Dependabot alerts
 
+[features]
+default = ["ambient-light"]
+ambient-light = ["dep:scrap"]
 # HACK: Add a dummy feature to the program because rust-analyzer doesn't want
 # to enable linux-pkg-config itself for whatever reason
-[features]
-scrap-pkg-config = ["scrap/linux-pkg-config"]
+scrap-pkg-config = ["ambient-light", "scrap/linux-pkg-config"]
 
 [package.metadata.vcpkg]
 git = "https://github.com/microsoft/vcpkg"

--- a/app/src/cli.rs
+++ b/app/src/cli.rs
@@ -1,6 +1,6 @@
 use std::{convert::TryInto, path::PathBuf, str::FromStr};
 
-use clap::{arg, command, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use error_stack::{Result, ResultExt};
 use strum::IntoEnumIterator;
 use thiserror::Error;
@@ -198,6 +198,11 @@ fn parse_cli() -> Result<CliOutput, CliError> {
                 save,
             } => {
                 let direction = direction.unwrap_or_default();
+                #[cfg(not(feature = "ambient-light"))]
+                if matches!(effect, Effects::AmbientLight { .. }) {
+                    println!("Error: AmbientLight effect is not available in this build.");
+                    std::process::exit(1);
+                }
                 let rgb_array = if effect.takes_color_array() {
                     colors.unwrap_or_else(|| {
                         println!("This effect requires specifying the colors to use.");
@@ -232,13 +237,20 @@ fn parse_cli() -> Result<CliOutput, CliError> {
             Commands::List => {
                 println!("List of available effects:");
                 for (i, effect) in Effects::iter().enumerate() {
+                    #[cfg(feature = "ambient-light")]
+                    let show = true;
+                    #[cfg(not(feature = "ambient-light"))]
+                    let show = !matches!(effect, Effects::AmbientLight { .. });
+                    if !show {
+                        continue;
+                    }
                     println!("{}. {effect}", i + 1);
                 }
                 return Ok(CliOutput::Cli(OutputType::Exit));
             }
 
             Commands::LoadProfile { path } => {
-                let profile = Profile::load_profile(&path).change_context(CliError)?;
+                let profile = Profile::load_profile(&path).change_context(CliError)?.normalize_effect();
                 return Ok(CliOutput::Gui {
                     hide_window: cli.hide_window,
                     output_type: OutputType::Profile(profile),

--- a/app/src/gui/menu_bar.rs
+++ b/app/src/gui/menu_bar.rs
@@ -44,7 +44,7 @@ impl MenuBarState {
             if let Some(path) = self.load_profile_dialog.path().map(|p| p.to_path_buf()) {
                 match Profile::load_profile(&path) {
                     Ok(profile) => {
-                        *current_profile = profile;
+                        *current_profile = profile.normalize_effect();
                         *changed = true;
                     }
                     Err(_) => {

--- a/app/src/gui/mod.rs
+++ b/app/src/gui/mod.rs
@@ -368,6 +368,13 @@ impl App {
                     ScrollArea::vertical().show(ui, |ui| {
                         ui.with_layout(Layout::top_down_justified(Align::Min), |ui| {
                             for val in Effects::iter() {
+                                #[cfg(feature = "ambient-light")]
+                                let show = true;
+                                #[cfg(not(feature = "ambient-light"))]
+                                let show = !matches!(val, Effects::AmbientLight { .. });
+                                if !show {
+                                    continue;
+                                }
                                 let text: &'static str = val.into();
                                 if ui.selectable_value(&mut self.current_profile.effect, val, text).clicked() {
                                     self.state_changed = true;

--- a/app/src/manager/effects/mod.rs
+++ b/app/src/manager/effects/mod.rs
@@ -1,5 +1,7 @@
 use default_ui::{show_brightness, show_direction, show_effect_settings};
-use eframe::egui::{self, ComboBox, Slider};
+use eframe::egui::{self, ComboBox};
+#[cfg(feature = "ambient-light")]
+use eframe::egui::Slider;
 use strum::IntoEnumIterator;
 
 use crate::{
@@ -7,6 +9,7 @@ use crate::{
     manager::profile::Profile,
 };
 
+#[cfg(feature = "ambient-light")]
 pub mod ambient;
 pub mod christmas;
 pub mod default_ui;
@@ -37,6 +40,7 @@ pub fn show_effect_ui(ui: &mut egui::Ui, profile: &mut Profile, update_lights: &
                 *update_lights |= ui.add_enabled(matches!(mode, SwipeMode::Fill), egui::Checkbox::new(clean_with_black, "Clean with black")).changed();
             });
         }
+        #[cfg(feature = "ambient-light")]
         Effects::AmbientLight { fps, saturation_boost } => {
             ui.scope(|ui| {
                 ui.style_mut().spacing.item_spacing = theme.spacing.default;

--- a/app/src/manager/mod.rs
+++ b/app/src/manager/mod.rs
@@ -1,7 +1,9 @@
 use crate::enums::{Direction, Effects, Message};
 
 use crossbeam_channel::{Receiver, Sender};
-use effects::{ambient, christmas, disco, fade, lightning, ripple, swipe, temperature};
+#[cfg(feature = "ambient-light")]
+use effects::ambient;
+use effects::{christmas, disco, fade, lightning, ripple, swipe, temperature};
 use error_stack::{Result, ResultExt};
 use legion_rgb_driver::{BaseEffects, Keyboard, SPEED_RANGE};
 use profile::Profile;
@@ -185,6 +187,7 @@ impl Inner {
                 self.keyboard.set_effect(effect).unwrap();
             }
             Effects::Lightning => lightning::play(self, profile, rng),
+            #[cfg(feature = "ambient-light")]
             Effects::AmbientLight { mut fps, mut saturation_boost } => {
                 fps = fps.clamp(1, 60);
                 saturation_boost = saturation_boost.clamp(0.0, 1.0);
@@ -200,6 +203,10 @@ impl Inner {
             Effects::Fade => fade::play(self, profile),
             Effects::Temperature => temperature::play(self),
             Effects::Ripple => ripple::play(self, profile),
+            #[cfg(not(feature = "ambient-light"))]
+            Effects::AmbientLight { .. } => {
+                eprintln!("Warning: AmbientLight effect is not available in this build. Install with `--features ambient-light` to enable.");
+            }
         }
     }
 

--- a/app/src/manager/profile.rs
+++ b/app/src/manager/profile.rs
@@ -72,6 +72,15 @@ impl Profile {
     pub fn rgb_array(&self) -> [u8; 12] {
         self.rgb_zones.map(|zone| if zone.enabled { zone.rgb } else { [0; 3] }).concat().try_into().unwrap()
     }
+
+    pub fn normalize_effect(self) -> Self {
+        #[cfg(not(feature = "ambient-light"))]
+        if matches!(self.effect, Effects::AmbientLight { .. }) {
+            eprintln!("Warning: Profile uses AmbientLight effect which is not available in this build. Falling back to Static.");
+            return Self { effect: Effects::Static, ..self };
+        }
+        self
+    }
 }
 
 pub fn arr_to_zones(arr: [u8; 12]) -> Zones {


### PR DESCRIPTION
Some users may not need the ambient light effect and would like to build without it (and all the vcpkg cruft).

This commit adds an enabled by default cargo feature `ambient-light` that enables all the ambient light functionality.

When `--no-default-features` is used, we don't need `scrap`, which from what I can tell is the only dependency that requires `vcpkg`.

Also updated the README to include instructions for building without `vcpkg`.

Assisted-by: OpenCode:Qwen3.6-35B-A3B