### PR TITLE
fix(cli): Only open gui if `--gui` on `load-profile` and `custom-effect`

### DIFF
--- a/app/src/cli.rs
+++ b/app/src/cli.rs
@@ -239,18 +239,26 @@ fn parse_cli() -> Result<CliOutput, CliError> {
 
             Commands::LoadProfile { path } => {
                 let profile = Profile::load_profile(&path).change_context(CliError)?;
-                return Ok(CliOutput::Gui {
-                    hide_window: cli.hide_window,
-                    output_type: OutputType::Profile(profile),
-                });
+                if cli.gui {
+                    return Ok(CliOutput::Gui {
+                        hide_window: cli.hide_window,
+                        output_type: OutputType::Profile(profile),
+                    });
+                } else {
+                    return Ok(CliOutput::Cli(OutputType::Profile(profile)));
+                }
             }
 
             Commands::CustomEffect { path } => {
                 let effect = CustomEffect::from_file(&path).change_context(CliError)?;
-                return Ok(CliOutput::Gui {
-                    hide_window: cli.hide_window,
-                    output_type: OutputType::Custom(effect),
-                });
+                if cli.gui {
+                    return Ok(CliOutput::Gui {
+                        hide_window: cli.hide_window,
+                        output_type: OutputType::Custom(effect),
+                    });
+                } else {
+                    return Ok(CliOutput::Cli(OutputType::Custom(effect)));
+                }
             }
         }
     }


### PR DESCRIPTION
As far as I can tell, we don't need to always open the GUI when running `load-profile`, and some users may want to load a profile on startup (for example, via a systemd service) without the GUI coming up.

Assisted-by: OpenCode:Qwen3.6-35B-A3B